### PR TITLE
feat(vault): exclude ambiguous characters from password generator

### DIFF
--- a/apps/extension/src/password/generator.test.ts
+++ b/apps/extension/src/password/generator.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { generatePassword, AMBIGUOUS_CHARS } from "./generator";
+
+describe("generatePassword", () => {
+  it("respects requested length", () => {
+    const pw = generatePassword({
+      length: 24,
+      lowercase: true,
+      uppercase: true,
+      numbers: true,
+      symbols: true,
+    });
+    expect(pw).toHaveLength(24);
+  });
+
+  it("throws when no character sets are selected", () => {
+    expect(() =>
+      generatePassword({
+        length: 12,
+        lowercase: false,
+        uppercase: false,
+        numbers: false,
+        symbols: false,
+      }),
+    ).toThrow();
+  });
+
+  it("excludes ambiguous characters when excludeAmbiguous is true", () => {
+    for (let i = 0; i < 50; i++) {
+      const pw = generatePassword({
+        length: 64,
+        lowercase: true,
+        uppercase: true,
+        numbers: true,
+        symbols: true,
+        excludeAmbiguous: true,
+      });
+      expect(pw).toHaveLength(64);
+      for (const ch of pw) {
+        expect(AMBIGUOUS_CHARS.includes(ch)).toBe(false);
+      }
+    }
+  });
+
+  it("still produces a valid password when only numbers are selected with excludeAmbiguous", () => {
+    const pw = generatePassword({
+      length: 32,
+      lowercase: false,
+      uppercase: false,
+      numbers: true,
+      symbols: false,
+      excludeAmbiguous: true,
+    });
+    expect(pw).toHaveLength(32);
+    expect(/^[2-9]+$/.test(pw)).toBe(true); // 0 and 1 stripped
+  });
+});

--- a/apps/extension/src/password/generator.ts
+++ b/apps/extension/src/password/generator.ts
@@ -3,12 +3,27 @@ const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const NUMBERS = "0123456789";
 const SYMBOLS = "!@#$%^&*()_+-=[]{}|;:,.<>?";
 
+// Characters that are visually similar and easy to confuse:
+// 0/O/o, 1/l/I/i, |/l, `/'
+export const AMBIGUOUS_CHARS = "0OoIl1i|`'";
+
 export interface PasswordOptions {
   length: number;
   lowercase: boolean;
   uppercase: boolean;
   numbers: boolean;
   symbols: boolean;
+  /** When true, removes visually ambiguous characters from the pool (default: false). */
+  excludeAmbiguous?: boolean;
+}
+
+function stripAmbiguous(charset: string): string {
+  const ambiguous = new Set(AMBIGUOUS_CHARS);
+  let out = "";
+  for (const ch of charset) {
+    if (!ambiguous.has(ch)) out += ch;
+  }
+  return out;
 }
 
 export function generatePassword(options: PasswordOptions): string {
@@ -18,6 +33,10 @@ export function generatePassword(options: PasswordOptions): string {
   if (options.uppercase) charset += UPPER;
   if (options.numbers) charset += NUMBERS;
   if (options.symbols) charset += SYMBOLS;
+
+  if (options.excludeAmbiguous) {
+    charset = stripAmbiguous(charset);
+  }
 
   if (!charset) {
     throw new Error("No character sets selected");

--- a/apps/vault-next/src/utils/passwordGenerator.ts
+++ b/apps/vault-next/src/utils/passwordGenerator.ts
@@ -3,12 +3,27 @@ const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const NUMBERS = "0123456789";
 const SYMBOLS = "!@#$%^&*()_+-=[]{}|;:,.<>?";
 
+// Characters that are visually similar and easy to confuse:
+// 0/O/o, 1/l/I/i, |/l, `/'
+export const AMBIGUOUS_CHARS = "0OoIl1i|`'";
+
 export interface PasswordOptions {
   length: number;
   lowercase: boolean;
   uppercase: boolean;
   numbers: boolean;
   symbols: boolean;
+  /** When true, removes visually ambiguous characters from the pool (default: false). */
+  excludeAmbiguous?: boolean;
+}
+
+function stripAmbiguous(charset: string): string {
+  const ambiguous = new Set(AMBIGUOUS_CHARS);
+  let out = "";
+  for (const ch of charset) {
+    if (!ambiguous.has(ch)) out += ch;
+  }
+  return out;
 }
 
 export function generatePassword(options: PasswordOptions): string {
@@ -18,6 +33,10 @@ export function generatePassword(options: PasswordOptions): string {
   if (options.uppercase) charset += UPPER;
   if (options.numbers) charset += NUMBERS;
   if (options.symbols) charset += SYMBOLS;
+
+  if (options.excludeAmbiguous) {
+    charset = stripAmbiguous(charset);
+  }
 
   if (!charset) {
     throw new Error("No character sets selected");


### PR DESCRIPTION
Closes #3

## What
Adds an `excludeAmbiguous` option to `PasswordOptions`. When enabled, visually similar characters (`0OoIl1i|\`'`) are stripped from the character pool before generation.

## Changes
- **apps/extension/src/password/generator.ts** — added `AMBIGUOUS_CHARS`, `stripAmbiguous()`, and the `excludeAmbiguous` option
- **apps/vault-next/src/utils/passwordGenerator.ts** — same change (both packages have their own generator)
- **apps/extension/src/password/generator.test.ts** — new vitest tests covering the option

## Notes
- Default is `false` — no breaking change to existing behavior
- Uses `crypto.getRandomValues` (existing pattern) for secure randomness